### PR TITLE
Forward unanswered query to next plugin

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/miekg/dns"
 
+	"github.com/coredns/coredns/plugin"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 )
 
@@ -105,13 +106,15 @@ func (t *Tailscale) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	}
 
-	log.Debugf("Writing response: %+v", msg)
-	w.WriteMsg(&msg)
+	if len(msg.Answer) > 0 {
+		log.Debugf("Writing response: %+v", msg)
+		w.WriteMsg(&msg)
+		return dns.RcodeSuccess, nil
+	}
 
 	// Export metric with the server label set to the current server handling the request.
 	//requestCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 
 	// Call next plugin (if any).
-	//return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
-	return 0, nil
+	return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
 }


### PR DESCRIPTION
If we can't answer the query, forward it to the next plugin. For example, to [forward](https://coredns.io/plugins/forward/). If there is no next plugin, reply with SERVFAIL.

My use case is I am using coredns as the nameserver for my LAN and tailnet, so I need it to resolve non-Tailscale hosts. 