### PR TITLE
Move build to Golang v1.20.

### DIFF
--- a/.github/workflows/go-package.yml
+++ b/.github/workflows/go-package.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Install dependencies
         run: go get .
       - name: Build


### PR DESCRIPTION
This version of Go is required by Tailscale 1.30.x.