### PR TITLE
Move build and Docker to Go 1.20

### DIFF
--- a/.github/workflows/go-package.yml
+++ b/.github/workflows/go-package.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Install dependencies
         run: go get .
       - name: Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS build
+FROM golang:1.20-alpine AS build
 
 WORKDIR /go/src/coredns
 


### PR DESCRIPTION
This bumps the Dockerfile base image and Github actions containers to Go 1.20. This version of Go is a requirement of the latest Tailscale libs.