### PR TITLE
Use go.mod for go version in workflow.

### DIFF
--- a/.github/workflows/go-package.yml
+++ b/.github/workflows/go-package.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
       - name: Install dependencies
         run: go get .
       - name: Build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damomurf/coredns-tailscale
 
-go 1.19
+go 1.20
 
 require (
 	github.com/coredns/caddy v1.1.1


### PR DESCRIPTION
Further attempt to fix CodeQL complaining about configuration issues.