### PR TITLE
fix: don't fallthrough by default

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -82,6 +82,17 @@ func (t *Tailscale) resolveCNAME(domainName string, msg *dns.Msg, lookupType int
 
 }
 
+func (t *Tailscale) handleNoRecords(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, msg *dns.Msg) (int, error) {
+	if t.fall.Through(r.Question[0].Name) {
+		log.Debug("falling through")
+		return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
+	} else {
+		log.Debugf("Writing response: %+v", msg)
+		w.WriteMsg(msg)
+		return dns.RcodeNameError, nil
+	}
+}
+
 func (t *Tailscale) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	log.Debugf("Received request for name: %v", r.Question[0].Name)
 	log.Debugf("Tailscale peers list has %d entries", len(t.entries))
@@ -90,31 +101,32 @@ func (t *Tailscale) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	msg.SetReply(r)
 	msg.Authoritative = true
 
+	name := r.Question[0].Name
+
 	switch r.Question[0].Qtype {
 
 	case dns.TypeA:
 		log.Debug("Handling A record lookup")
-		t.resolveA(r.Question[0].Name, &msg)
+		t.resolveA(name, &msg)
 
 	case dns.TypeAAAA:
 		log.Debug("Handling AAAA record lookup")
-		t.resolveAAAA(r.Question[0].Name, &msg)
+		t.resolveAAAA(name, &msg)
 
 	case dns.TypeCNAME:
 		log.Debug("Handling CNAME record lookup")
-		t.resolveCNAME(r.Question[0].Name, &msg, TypeAll)
+		t.resolveCNAME(name, &msg, TypeAll)
 
 	}
 
-	if len(msg.Answer) > 0 {
-		log.Debugf("Writing response: %+v", msg)
-		w.WriteMsg(&msg)
-		return dns.RcodeSuccess, nil
+	if len(msg.Answer) == 0 {
+		return t.handleNoRecords(ctx, w, r, &msg)
 	}
 
 	// Export metric with the server label set to the current server handling the request.
 	//requestCount.WithLabelValues(metrics.WithServer(ctx)).Inc()
 
-	// Call next plugin (if any).
-	return plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
+	log.Debugf("Writing response: %+v", msg)
+	w.WriteMsg(&msg)
+	return dns.RcodeSuccess, nil
 }

--- a/serve_test.go
+++ b/serve_test.go
@@ -11,20 +11,25 @@ import (
 	"github.com/miekg/dns"
 )
 
-var ts = Tailscale{
-	zone: "example.com",
-	entries: map[string]map[string]string{
-		"test1": {
-			"A":    "127.0.0.1",
-			"AAAA": "::1",
+func newTS() Tailscale {
+	return Tailscale{
+		zone: "example.com",
+		entries: map[string]map[string]string{
+			"test1": {
+				"A":    "127.0.0.1",
+				"AAAA": "::1",
+			},
+			"test2": {
+				"CNAME": "test1.example.com",
+			},
 		},
-		"test2": {
-			"CNAME": "test1.example.com",
-		},
-	},
+	}
 }
 
-func TestServeDNS(t *testing.T) {
+func TestServeDNSFallback(t *testing.T) {
+	ts := newTS()
+	ts.fall.SetZonesFromArgs(nil)
+
 	test3 := net.ParseIP("100.100.100.100")
 
 	// No match, no next plugin.
@@ -79,7 +84,7 @@ func TestServeDNS(t *testing.T) {
 }
 
 func TestResolveA(t *testing.T) {
-
+	ts := newTS()
 	msg := dns.Msg{}
 
 	domain := "test1.example.com"
@@ -98,7 +103,7 @@ func TestResolveA(t *testing.T) {
 }
 
 func TestResolveAAAA(t *testing.T) {
-
+	ts := newTS()
 	msg := dns.Msg{}
 
 	domain := "test1.example.com"
@@ -117,7 +122,7 @@ func TestResolveAAAA(t *testing.T) {
 }
 
 func TestResolveCNAME(t *testing.T) {
-
+	ts := newTS()
 	msg := dns.Msg{}
 	domain := "test2.example.com"
 
@@ -142,7 +147,7 @@ func TestResolveCNAME(t *testing.T) {
 }
 
 func TestResolveAIsCNAME(t *testing.T) {
-
+	ts := newTS()
 	msg := dns.Msg{}
 	domain := "test2.example.com"
 
@@ -167,7 +172,7 @@ func TestResolveAIsCNAME(t *testing.T) {
 }
 
 func TestResolveAAAAIsCNAME(t *testing.T) {
-
+	ts := newTS()
 	msg := dns.Msg{}
 	domain := "test2.example.com"
 

--- a/setup.go
+++ b/setup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/fall"
 )
 
 // init registers this plugin.
@@ -18,18 +19,30 @@ func setup(c *caddy.Controller) error {
 	c.Next() // Ignore "tailscale" and give us the next token.
 	if c.NextArg() {
 		zone = c.Val()
-		c.Next()
+	}
+
+	f := fall.F{}
+
+	for c.NextBlock() {
+		switch c.Val() {
+		case "fallthrough":
+			f.SetZonesFromArgs(c.RemainingArgs())
+		default:
+			return c.Errf("unknown property '%s'", c.Val())
+		}
 	}
 	if c.NextArg() {
 		return plugin.Error("tailscale", c.ArgErr())
 	}
 
+	ts := &Tailscale{
+		zone: zone,
+		fall: f,
+	}
+
 	// Add the Plugin to CoreDNS, so Servers can use it in their plugin chain.
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		ts := &Tailscale{
-			Next: next,
-			zone: zone,
-		}
+		ts.Next = next
 		ts.pollPeers()
 		go func() {
 			for range time.Tick(1 * time.Minute) {

--- a/tailscale.go
+++ b/tailscale.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/plugin/pkg/fall"
 	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn/ipnstate"
 )
@@ -16,12 +16,7 @@ type Tailscale struct {
 	tsClient tailscale.LocalClient
 	entries  map[string]map[string]string
 	zone     string
-}
-
-func NewTailscale(next plugin.Handler) *Tailscale {
-	ts := Tailscale{Next: test.ErrorHandler()}
-	ts.pollPeers()
-	return &ts
+	fall     fall.F
 }
 
 // Name implements the Handler interface.


### PR DESCRIPTION
Adds support for the `fallthrough` directive and don't do it by default, [as suggested by the docs](https://coredns.io/manual/toc/#fallthrough).