### PR TITLE
read netmap updates from IPNBus rather than polling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/coredns/caddy v1.1.1
 	github.com/coredns/coredns v1.11.1
+	github.com/google/go-cmp v0.6.0
 	github.com/miekg/dns v1.1.56
 	tailscale.com v1.52.1
 )
@@ -21,7 +22,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.5.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20231101202521-4ca4178f5c7a // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hdevalence/ed25519consensus v0.1.0 // indirect

--- a/serve.go
+++ b/serve.go
@@ -109,8 +109,8 @@ func (t *Tailscale) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	name := r.Question[0].Name
 
+	t.mu.RLock()
 	switch r.Question[0].Qtype {
-
 	case dns.TypeA:
 		log.Debug("Handling A record lookup")
 		t.resolveA(name, &msg)
@@ -122,8 +122,8 @@ func (t *Tailscale) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	case dns.TypeCNAME:
 		log.Debug("Handling CNAME record lookup")
 		t.resolveCNAME(name, &msg, TypeAll)
-
 	}
+	defer t.mu.RUnlock()
 
 	if len(msg.Answer) == 0 {
 		return t.handleNoRecords(ctx, w, r, &msg)

--- a/setup.go
+++ b/setup.go
@@ -1,8 +1,6 @@
 package tailscale
 
 import (
-	"time"
-
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
@@ -43,12 +41,7 @@ func setup(c *caddy.Controller) error {
 	// Add the Plugin to CoreDNS, so Servers can use it in their plugin chain.
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		ts.Next = next
-		ts.pollPeers()
-		go func() {
-			for range time.Tick(1 * time.Minute) {
-				ts.pollPeers()
-			}
-		}()
+		go ts.watchIPNBus()
 		return ts
 	})
 

--- a/tailscale_test.go
+++ b/tailscale_test.go
@@ -1,0 +1,91 @@
+package tailscale
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/netmap"
+)
+
+func TestProcessNetMap(t *testing.T) {
+	ts := &Tailscale{zone: "example.com"}
+
+	self := (&tailcfg.Node{
+		ComputedName: "self",
+		Addresses: []netip.Prefix{
+			netip.MustParsePrefix("100.0.0.1/24"),
+			netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
+		},
+		Tags: []string{"tag:cname-app"},
+	}).View()
+
+	nm := &netmap.NetworkMap{
+		SelfNode: self,
+		Peers: []tailcfg.NodeView{
+			(&tailcfg.Node{
+				ComputedName: "peer",
+				Addresses: []netip.Prefix{
+					netip.MustParsePrefix("100.0.0.2/24"),
+					netip.MustParsePrefix("fd7a:115c:a1e0::2/128"),
+				},
+				Tags: []string{"tag:cname-app"},
+			}).View(),
+			(&tailcfg.Node{
+				// shared node should be excluded
+				ComputedName: "shared",
+				Sharer:       1,
+				Addresses: []netip.Prefix{
+					netip.MustParsePrefix("100.0.0.3/24"),
+					netip.MustParsePrefix("fd7a:115c:a1e0::3/128"),
+				},
+				Tags: []string{"tag:cname-app"},
+			}).View(),
+			(&tailcfg.Node{
+				// mullvad exit node should be excluded
+				ComputedName:    "mullvad",
+				IsWireGuardOnly: true,
+				Addresses: []netip.Prefix{
+					netip.MustParsePrefix("100.0.0.4/24"),
+					netip.MustParsePrefix("fd7a:115c:a1e0::4/128"),
+				},
+				Tags: []string{"tag:cname-app"},
+			}).View(),
+		},
+	}
+
+	want := map[string]map[string][]string{
+		"self": {
+			"A":    {"100.0.0.1"},
+			"AAAA": {"fd7a:115c:a1e0::1"},
+		},
+		"peer": {
+			"A":    {"100.0.0.2"},
+			"AAAA": {"fd7a:115c:a1e0::2"},
+		},
+		"app": {
+			"CNAME": {"self.example.com.", "peer.example.com."},
+		},
+	}
+
+	ts.processNetMap(nm)
+	if !cmp.Equal(ts.entries, want) {
+		t.Errorf("ts.entries = %v, want %v", ts.entries, want)
+	}
+
+	// now process another netmap with only self, and make sure peer is removed
+	ts.processNetMap(&netmap.NetworkMap{SelfNode: self})
+	want = map[string]map[string][]string{
+		"self": {
+			"A":    {"100.0.0.1"},
+			"AAAA": {"fd7a:115c:a1e0::1"},
+		},
+		"app": {
+			"CNAME": {"self.example.com."},
+		},
+	}
+	if !cmp.Equal(ts.entries, want) {
+		t.Errorf("ts.entries = %v, want %v", ts.entries, want)
+	}
+}


### PR DESCRIPTION
This allows us to respond to node additions, removals, and renames in near-realtime instead of waiting a minute for the next poll event. Protect DNS entries map in a RWMutex.

This also uses the Tailscale computed hostname for DNS entries, rather than the reported hostname from the operating system. These can differ if another host already exists on the tailnet with that name, or if an admin has manually changed the name in the Tailscale admin panel. This now ensures that we are using the same hostname that's actually used on the tailnet.

This change also removes entries for nodes that have been shared into the tailnet. These hosts don't have unique names within the tailnet and must be addressed using the FQDN for their own tailnet. Because of that, I'm not sure that it ever makes sense to add DNS entries for these nodes, but this leaves a TODO to reconsider that in the future.