### PR TITLE
Bump to Golang 1.21 required for latest Tailscale.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damomurf/coredns-tailscale
 
-go 1.20
+go 1.21
 
 require (
 	github.com/coredns/caddy v1.1.1


### PR DESCRIPTION
We need to bump to the very latest Tailscale version which relies on Golang 1.21