### PR TITLE
Disable docker build provenance (fix unknown/unknown arch)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Disabling provenance attestation for the docker build addresses a known bug in `build-push-action@v5` where the OS arch is tagged as `unknown/unknown`. (See issue https://github.com/docker/build-push-action/issues/820)

Addresses issue #73 