### PR TITLE
Bump image build to use coredns 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.22.0-alpine3.19 AS build
 WORKDIR /go/src/coredns
 
 RUN apk add git make && \
-    git clone --depth 1 --branch=v1.11.1 https://github.com/coredns/coredns /go/src/coredns && cd plugin
+    git clone --depth 1 --branch=v1.11.2 https://github.com/coredns/coredns /go/src/coredns && cd plugin
 
 COPY . /go/src/coredns/plugin/tailscale
 


### PR DESCRIPTION
Bumping docker build dependency to CoreDNS 1.11.2 in line with https://github.com/damomurf/coredns-tailscale/pull/77.