### PR TITLE
enable the device web UI for tsnet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/damomurf/coredns-tailscale
 
-go 1.22
+go 1.22.0
+
 toolchain go1.22.1
 
 require (

--- a/tailscale.go
+++ b/tailscale.go
@@ -41,9 +41,10 @@ func (t *Tailscale) start() error {
 	if t.authkey != "" {
 		// authkey was provided, so startup a local tsnet server
 		t.srv = &tsnet.Server{
-			Hostname: "coredns",
-			AuthKey:  t.authkey,
-			Logf:     log.Debugf,
+			Hostname:     "coredns",
+			AuthKey:      t.authkey,
+			Logf:         log.Debugf,
+			RunWebClient: true,
 		}
 		err := t.srv.Start()
 		if err != nil {


### PR DESCRIPTION
Since v1.56, Tailscale has a built-in web interface that can be used to manage the device remotely over your tailnet. It is still subject to the ACLs on the tailnet, so just enabling the interface (this change) doesn't immediately expose anything. It just make it possible to configure ACL access to remotely manage the device.  You will be able to navigate to http://coredns:5252/ (or whatever your device is named) to manage it.

We recently made the same change to our golink service, as we believe it is safe to enable this by default for these types of services: https://github.com/tailscale/golink/pull/114

More info: https://tailscale.com/kb/1325/device-web-interface

(This also has a minor change to `go.mod` which is just the result of running `go mod tidy`.  Apparently it's wants the full version string?)