### PR TITLE
Revert upstream CoreDNS tag to v1.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.22.0-alpine3.19 AS build
+FROM golang:1.22.2-alpine3.19 AS build
 
 WORKDIR /go/src/coredns
 
 RUN apk add git make && \
-    git clone --depth 1 --branch=v1.11.2 https://github.com/coredns/coredns /go/src/coredns && cd plugin
+    git clone --depth 1 --branch=v1.11.1 https://github.com/coredns/coredns /go/src/coredns && cd plugin
 
 COPY . /go/src/coredns/plugin/tailscale
 


### PR DESCRIPTION
Somewhat mysteriously the upstream CoreDNS v1.11.2 tag has been removed, so reverting to v1.11.1 - also bumping golang image to latest.