### PR TITLE
Fix container image build to use binaries only.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN cd plugin && \
     make check && \
     go build
 
-# FROM alpine:3.19.1
-# RUN apk add --no-cache ca-certificates
+FROM alpine:3.19.1
+RUN apk add --no-cache ca-certificates
 
-# COPY --from=build /go/src/coredns/coredns /
-# COPY Corefile run.sh /
+COPY --from=build /go/src/coredns/coredns /
+COPY Corefile run.sh /
 
-# ENTRYPOINT ["/run.sh"]
-
+ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
The current multi-architecture container builds are massive because the go build environment and source code are included.

Only add the coredns binary to the final image with a run.sh script and a sample Corefile.