### PR TITLE
Bumps to Go v1.23.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine3.19 AS build
+FROM golang:1.23.2-alpine3.19 AS build
 
 WORKDIR /go/src/coredns
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/damomurf/coredns-tailscale
 
-go 1.22.0
+go 1.23.2
 
-toolchain go1.22.1
+toolchain go1.23.2
 
 require (
 	github.com/coredns/caddy v1.1.1


### PR DESCRIPTION
Bump golang to v1.23.2 to prepare for incoming Tailscale version requirement.