### PR TITLE
Add the possibility to configure the tailscale hostname

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -28,8 +28,15 @@ func setup(c *caddy.Controller) error {
 					return plugin.Error("tailscale", c.ArgErr())
 				}
 				ts.authkey = args[0]
+			case "hostname":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return plugin.Error("tailscale", c.ArgErr())
+				}
+				ts.hostname = args[0]
 			case "fallthrough":
 				ts.fall.SetZonesFromArgs(c.RemainingArgs())
+
 			default:
 				return plugin.Error("tailscale", c.ArgErr())
 			}

--- a/tailscale.go
+++ b/tailscale.go
@@ -21,9 +21,10 @@ type Tailscale struct {
 	zone string
 	fall fall.F
 
-	authkey string
-	srv     *tsnet.Server
-	lc      *tailscale.LocalClient
+	authkey  string
+	hostname string
+	srv      *tsnet.Server
+	lc       *tailscale.LocalClient
 
 	mu      sync.RWMutex
 	entries map[string]map[string][]string
@@ -39,9 +40,13 @@ func (t *Tailscale) Name() string { return "tailscale" }
 // instead of connecting to the local tailscaled instance.
 func (t *Tailscale) start() error {
 	if t.authkey != "" {
+		hostname := t.hostname
+		if t.hostname == "" {
+			hostname = "coredns"
+		}
 		// authkey was provided, so startup a local tsnet server
 		t.srv = &tsnet.Server{
-			Hostname:     "coredns",
+			Hostname:     hostname,
 			AuthKey:      t.authkey,
 			Logf:         log.Debugf,
 			RunWebClient: true,


### PR DESCRIPTION
if no hostname is provided the default one "coredns" is used.