### PR TITLE
Set IPN bus notify option "NotifyNoPrivateKeys"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/henrikvtcodes/coredns-tailscale
+module github.com/damomurf/coredns-tailscale
 
 go 1.23.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/damomurf/coredns-tailscale
+module github.com/henrikvtcodes/coredns-tailscale
 
 go 1.23.2
 

--- a/tailscale.go
+++ b/tailscale.go
@@ -72,7 +72,7 @@ func (t *Tailscale) start() error {
 // This function does not return. If it is unable to read from the IPN Bus, it will continue to retry.
 func (t *Tailscale) watchIPNBus() {
 	for {
-		watcher, err := t.lc.WatchIPNBus(context.Background(), ipn.NotifyInitialNetMap)
+		watcher, err := t.lc.WatchIPNBus(context.Background(), ipn.NotifyInitialNetMap|ipn.NotifyNoPrivateKeys)
 		if err != nil {
 			log.Info("unable to read from Tailscale event bus, retrying in 1 minute")
 			time.Sleep(1 * time.Minute)


### PR DESCRIPTION
While running this plugin in my own CoreDNS setup, I ran into issues where my coredns service (running with its own user a group) could not connect to the local Tailscale socket, even if the Tailscale socket was owned by a group that the coredns user was a part of. Setting this bitflag allows Tailscale to respond to these requests that do not require sensitive information. 

I have tested this change in my own DNS setup and it works as intended.

Tailscale source link: 
https://github.com/tailscale/tailscale/blob/main/ipn/backend.go#L77  
https://github.com/tailscale/tailscale/blob/main/ipn/localapi/localapi.go#L1284