### PR TITLE
Fix: Case-insensitive hostname lookup for DNS requests

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -24,7 +24,7 @@ const (
 
 func (t *Tailscale) resolveA(domainName string, msg *dns.Msg) {
 
-	name := strings.Split(domainName, ".")[0]
+	name := strings.TrimSuffix(strings.ToLower(domainName), ".")
 	entries, ok := t.entries[name]["A"]
 	if ok {
 		log.Debugf("Found an v4 entry after lookup for: %s", name)
@@ -44,7 +44,7 @@ func (t *Tailscale) resolveA(domainName string, msg *dns.Msg) {
 
 func (t *Tailscale) resolveAAAA(domainName string, msg *dns.Msg) {
 
-	name := strings.Split(domainName, ".")[0]
+	name := strings.TrimSuffix(strings.ToLower(domainName), ".")
 	entries, ok := t.entries[name]["AAAA"]
 	if ok {
 		log.Debugf("Found a v6 entry after lookup for: %s", name)
@@ -64,7 +64,7 @@ func (t *Tailscale) resolveAAAA(domainName string, msg *dns.Msg) {
 
 func (t *Tailscale) resolveCNAME(domainName string, msg *dns.Msg, lookupType int) {
 
-	name := strings.Split(domainName, ".")[0]
+	name := strings.TrimSuffix(strings.ToLower(domainName), ".")
 	targets, ok := t.entries[name]["CNAME"]
 	if ok {
 		log.Debugf("Found a CNAME entry after lookup for: %s", name)

--- a/serve.go
+++ b/serve.go
@@ -24,7 +24,7 @@ const (
 
 func (t *Tailscale) resolveA(domainName string, msg *dns.Msg) {
 
-	name := strings.TrimSuffix(strings.ToLower(domainName), ".")
+	name := strings.Split(strings.ToLower(domainName), ".")[0]
 	entries, ok := t.entries[name]["A"]
 	if ok {
 		log.Debugf("Found an v4 entry after lookup for: %s", name)
@@ -44,7 +44,7 @@ func (t *Tailscale) resolveA(domainName string, msg *dns.Msg) {
 
 func (t *Tailscale) resolveAAAA(domainName string, msg *dns.Msg) {
 
-	name := strings.TrimSuffix(strings.ToLower(domainName), ".")
+	name := strings.Split(strings.ToLower(domainName), ".")[0]
 	entries, ok := t.entries[name]["AAAA"]
 	if ok {
 		log.Debugf("Found a v6 entry after lookup for: %s", name)
@@ -64,7 +64,7 @@ func (t *Tailscale) resolveAAAA(domainName string, msg *dns.Msg) {
 
 func (t *Tailscale) resolveCNAME(domainName string, msg *dns.Msg, lookupType int) {
 
-	name := strings.TrimSuffix(strings.ToLower(domainName), ".")
+	name := strings.Split(strings.ToLower(domainName), ".")[0]
 	targets, ok := t.entries[name]["CNAME"]
 	if ok {
 		log.Debugf("Found a CNAME entry after lookup for: %s", name)


### PR DESCRIPTION
This change updates:

name := strings.Split(domainName, ".")[0]

to:

name := strings.Split(strings.ToLower(domainName), ".")[0]

to ensure proper matching of hostnames regardless of case.

Google DNS resolvers randomize the case of DNS queries (e.g. ZaBbix.Ipn.Neoteq.Be.), which caused lookups to fail due to strict string comparison. Converting the domain name to lowercase ensures consistent and correct resolution.

This should fix issue #67. 

Sorry about my first pull request. It was submitted by mistake. :)