### PR TITLE
Bump golang version for Tailscale requirement.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.24.5-alpine3.21 AS build
+FROM golang:1.25.1-alpine3.22 AS build
 
 WORKDIR /go/src/coredns
 
 RUN apk add git make && \
-    git clone --depth 1 --branch=v1.11.3 https://github.com/coredns/coredns /go/src/coredns && cd plugin
+    git clone --depth 1 --branch=v1.12.4 https://github.com/coredns/coredns /go/src/coredns && cd plugin
 
 COPY . /go/src/coredns/plugin/tailscale
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damomurf/coredns-tailscale
 
-go 1.24.5
+go 1.25.1
 
 require (
 	github.com/coredns/caddy v1.1.2-0.20241029205200-8de985351a98


### PR DESCRIPTION
Tailscale 1.88.1 requires at least Golang 1.25.1.