### PR TITLE
Tailscale services support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
-coredns-tailscale
-=================
+# coredns-tailscale
 
 A CoreDNS plugin implementation for Tailscale networks.
 
-Rationale
----------
+## Rationale
 
 Tailscale has some great built-in support for DNS and it keeps getting better. But there are some nice (if not purely cosmetic) reasons to be able to have Tailscale hosts resolve within your own existing domain. In addition, it's common for various services to run at a single Tailscale IP, for example, on a load balancer or web server hosting multiple virtual hosts.
 
-Features
---------
+## Features
+
 This plugin for CoreDNS allows the following:
 
 1. Automatically serving an (arbitrary) DNS zone with each Tailscale server in your Tailnet added with A and AAAA records.
 1. Allowing CNAME records to be defined via Tailscale node tags that link logical names to Tailscale machines.
+1. Exposing [Tailscale Services](https://tailscale.com/docs/features/tailscale-services) entries
 
 
-Configuration
--------------
+## Configuration
+
+The configurations below will serve the connected Tailnet on the `example.com` domain. So, for a Tailnet with a machine named `test-machine`, A and AAAA records for `test-machine.example.com` will resolve.
+
+### Using a Tailscale AuthKey
+
+```
+example.com:53 {
+  tailscale example.com {
+    authkey <authkey-from-admin-console>
+    hostname <hostname>
+  }
+}
+```
+
+Obtain an auth key from the Tailscale admin console at (https://login.tailscale.com/admin/settings/keys). The hostname field defines what Tailscale node this plugin will appear as in your Tailscale Machines list.
+
+_Note that this auth key will expire_.
+
+### Using the local Tailscale Socket
 
 ```
 example.com:53 {
@@ -26,10 +43,12 @@ example.com:53 {
   errors
 }
 ```
-The above configuration will serve the connected Tailnet on the `example.com`. So, for a Tailnet with a machine named `test-machine`, A and AAAA records for `test-machine.example.com` will resolve.
 
-CNAME records via Labels
-------------------------
+This approach uses local machine Tailscale socket to access Tailnet information. As a result, only machines reachable from the hosting Tailscale machine will be configured in DNS. Those machines are the ones output in `tailscale status` output (and the machine itself).
+
+If using a container to run coredns-tailscale, the Tailscale socket will need to be mounted in to the container for `coredns-tailscale` to be able to connect to it.
+
+## CNAME records via Labels
 
 A CNAME record can be added to point to a machine by simply creating a Tailscale machine tag prefixed by `cname-`. Any text in the tag after that prefix will be used to generate the resulting CNAME entry, so for example, the tag `cname-friendly-name` on the above `test-machine` will result in the following DNS records:
 
@@ -39,13 +58,11 @@ test-machine  IN A <Tailscale IPv4 Address>
 test-machine  IN AAAA <Tailscale IPv6 Address>
 ```
 
-Tailscale
----------
-Note that currently this plugin uses the local machine Tailscale socket to access Tailnet information. As a result, only machines reachable from the hosting Tailscale machine will be configured in DNS. Those machines are the ones output in `tailscale status` output (and the machine itself). This was implemented to avoid the need for managing expiring Tailscale API tokens.
+## Services
 
+[Tailscale Services](https://tailscale.com/docs/features/tailscale-services) are an alternative way to expose underlying services to your Tailnet. `coredns-tailscale` will retrieve Services entries based on their name (without the Tailnet domain) and expose their corresponding `A` and `AAAA` records in the configured CoreDNS domain. 
 
-TODO
-----
-   * Update documentation to CoreDNS plugin [documentation standard](https://github.com/coredns/coredns/blob/master/plugin.md#documentation)
-   * Add metrics support
+## TODO
+
+   * Support Tailscale API key to avoid expiring auth keys
 

--- a/serve.go
+++ b/serve.go
@@ -102,6 +102,7 @@ func (t *Tailscale) handleNoRecords(ctx context.Context, w dns.ResponseWriter, r
 func (t *Tailscale) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	log.Debugf("Received request for name: %v", r.Question[0].Name)
 	log.Debugf("Tailscale peers list has %d entries", len(t.entries))
+	log.Debugf("Peers list: %+v", t.entries)
 
 	msg := dns.Msg{}
 	msg.SetReply(r)

--- a/tailscale.go
+++ b/tailscale.go
@@ -145,6 +145,31 @@ func (t *Tailscale) processNetMap(nm *netmap.NetworkMap) {
 		entries[hostname] = entry
 	}
 
+	log.Debug("Looking for service VIPs")
+	svcs := nm.GetVIPServiceIPMap()
+	for svcname, svc := range svcs {
+		if name, ok := strings.CutPrefix(string(svcname), "svc:"); ok {
+			log.Debugf("Found service entry: %s", name)
+
+			entry, ok := entries[name]
+			if !ok {
+				entry = map[string][]string{}
+			}
+
+			for _, addr := range svc {
+				if addr.Is4() {
+					entry["A"] = append(entry["A"], addr.String())
+				} else if addr.Is6() {
+					entry["AAAA"] = append(entry["AAAA"], addr.String())
+				}
+				log.Debugf("Added entry %+v", entry)
+			}
+
+			entries[name] = entry
+		}
+
+	}
+
 	t.mu.Lock()
 	t.entries = entries
 	t.mu.Unlock()

--- a/tailscale.go
+++ b/tailscale.go
@@ -3,6 +3,7 @@ package tailscale
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -87,15 +88,14 @@ func (t *Tailscale) watchIPNBus() {
 				watcher.Close()
 				break
 			}
-			t.processNetMap(n.NetMap)
+			if n.NetMap != nil {
+				t.processNetMap(n.NetMap)
+			}
 		}
 	}
 }
 
 func (t *Tailscale) processNetMap(nm *netmap.NetworkMap) {
-	if nm == nil {
-		return
-	}
 
 	log.Debugf("Self tags: %+v", nm.SelfNode.Tags().AsSlice())
 	nodes := []tailcfg.NodeView{nm.SelfNode}
@@ -145,29 +145,22 @@ func (t *Tailscale) processNetMap(nm *netmap.NetworkMap) {
 		entries[hostname] = entry
 	}
 
-	log.Debug("Looking for service VIPs")
-	svcs := nm.GetVIPServiceIPMap()
-	for svcname, svc := range svcs {
-		if name, ok := strings.CutPrefix(string(svcname), "svc:"); ok {
-			log.Debugf("Found service entry: %s", name)
-
-			entry, ok := entries[name]
-			if !ok {
-				entry = map[string][]string{}
-			}
-
-			for _, addr := range svc {
-				if addr.Is4() {
-					entry["A"] = append(entry["A"], addr.String())
-				} else if addr.Is6() {
-					entry["AAAA"] = append(entry["AAAA"], addr.String())
-				}
-				log.Debugf("Added entry %+v", entry)
-			}
-
-			entries[name] = entry
+	// Grab service (VIP) definitions from the only place the API seems to return them accessible
+	// via the netmap.
+	for _, rec := range nm.DNS.ExtraRecords {
+		name := strings.Split(rec.Name, ".")[0]
+		ip, err := netip.ParseAddr(rec.Value)
+		if err != nil {
+			log.Errorf("Error parsing DNS extra record value \"%s\" as netip: %v", rec.Value, err)
 		}
-
+		if _, ok := entries[name]; !ok {
+			entries[name] = map[string][]string{}
+		}
+		if ip.Is6() {
+			entries[name]["AAAA"] = append(entries[name]["AAAA"], ip.String())
+		} else {
+			entries[name]["A"] = append(entries[name]["A"], ip.String())
+		}
 	}
 
 	t.mu.Lock()

--- a/tailscale_test.go
+++ b/tailscale_test.go
@@ -53,6 +53,18 @@ func TestProcessNetMap(t *testing.T) {
 				Tags: []string{"tag:cname-app"},
 			}).View(),
 		},
+		DNS: tailcfg.DNSConfig{
+			ExtraRecords: []tailcfg.DNSRecord{
+				{
+					Name:  "vip-service.tail-scale.ts.net",
+					Value: "100.0.0.5",
+				},
+				{
+					Name:  "vip-service.tail-scale.ts.net",
+					Value: "fd7a:115c:a1e0::5",
+				},
+			},
+		},
 	}
 
 	want := map[string]map[string][]string{
@@ -66,6 +78,10 @@ func TestProcessNetMap(t *testing.T) {
 		},
 		"app": {
 			"CNAME": {"self.example.com.", "peer.example.com."},
+		},
+		"vip-service": {
+			"A":    {"100.0.0.5"},
+			"AAAA": {"fd7a:115c:a1e0::5"},
 		},
 	}
 


### PR DESCRIPTION
Expose Tailscale services (https://tailscale.com/docs/features/tailscale-services) by exposing their name as entries in CoreDNS.

Update README to include services functionality and (finally) document the tsnet authkey approach to joining the Tailnet.