### PR TITLE
Add optional DNS server on Tailscale interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This plugin for CoreDNS allows the following:
 1. Automatically serving an (arbitrary) DNS zone with each Tailscale server in your Tailnet added with A and AAAA records.
 1. Allowing CNAME records to be defined via Tailscale node tags that link logical names to Tailscale machines.
 1. Exposing [Tailscale Services](https://tailscale.com/docs/features/tailscale-services) entries
+1. Running a DNS server on the Tailscale network interface (UDP/TCP port 53)
 
 
 ## Configuration
@@ -62,7 +63,22 @@ test-machine  IN AAAA <Tailscale IPv6 Address>
 
 [Tailscale Services](https://tailscale.com/docs/features/tailscale-services) are an alternative way to expose underlying services to your Tailnet. `coredns-tailscale` will retrieve Services entries based on their name (without the Tailnet domain) and expose their corresponding `A` and `AAAA` records in the configured CoreDNS domain. 
 
+## Tailnet DNS Server
+
+The plugin can optionally run a DNS server on the Tailscale network interface listening on UDP and TCP port 53. The DNS server is disabled by default. To enable it, use `dns on`:
+
+```
+example.com:53 {
+  tailscale example.com {
+    authkey <authkey>
+    hostname <hostname>
+    dns on
+  }
+}
+```
+
+Other machines in your tailnet can query this DNS server by using its Tailscale IP address. For example, if your CoreDNS node has Tailscale IP `100.64.0.1`, other nodes can configure their DNS resolver to use `100.64.0.1:53`. (You can also easily use the IP for a split DNS configuration in Tailscale.)
+
 ## TODO
 
    * Support Tailscale API key to avoid expiring auth keys
-

--- a/setup.go
+++ b/setup.go
@@ -36,6 +36,18 @@ func setup(c *caddy.Controller) error {
 				ts.hostname = args[0]
 			case "fallthrough":
 				ts.fall.SetZonesFromArgs(c.RemainingArgs())
+			case "dns":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return plugin.Error("tailscale", c.ArgErr())
+				}
+				if args[0] == "on" {
+					ts.serveDNS = true
+				} else if args[0] == "off" {
+					ts.serveDNS = false
+				} else {
+					return plugin.Error("tailscale", c.ArgErr())
+				}
 
 			default:
 				return plugin.Error("tailscale", c.ArgErr())

--- a/tailscale.go
+++ b/tailscale.go
@@ -3,6 +3,7 @@ package tailscale
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
 	"strings"
 	"sync"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/fall"
+	"github.com/miekg/dns"
 	"tailscale.com/client/local"
 	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
@@ -22,13 +24,18 @@ type Tailscale struct {
 	zone string
 	fall fall.F
 
-	authkey  string
-	hostname string
-	srv      *tsnet.Server
-	lc       *local.Client
+	authkey     string
+	hostname    string
+	srv         *tsnet.Server
+	lc          *local.Client
+	serveDNS    bool
 
 	mu      sync.RWMutex
 	entries map[string]map[string][]string
+
+	dnsServer *dns.Server
+	dnsConn   net.PacketConn
+	dnsTCP    net.Listener
 }
 
 // Name implements the Handler interface.
@@ -66,6 +73,24 @@ func (t *Tailscale) start() error {
 	}
 
 	go t.watchIPNBus()
+
+	if t.serveDNS {
+		go func() {
+			for i := 0; i < 30; i++ {
+				ip4, ip6 := t.srv.TailscaleIPs()
+				if ip4.IsValid() || ip6.IsValid() {
+					if err := t.startDNSServer(); err != nil {
+						log.Errorf("Failed to start DNS server: %v", err)
+					}
+					return
+				}
+				log.Debugf("Waiting for Tailscale IP assignment... (%d/30)", i+1)
+				time.Sleep(1 * time.Second)
+			}
+			log.Error("Timeout waiting for Tailscale IP, DNS server not started")
+		}()
+	}
+
 	return nil
 }
 
@@ -167,4 +192,58 @@ func (t *Tailscale) processNetMap(nm *netmap.NetworkMap) {
 	t.entries = entries
 	t.mu.Unlock()
 	log.Debugf("updated %d Tailscale entries", len(entries))
+}
+
+func (t *Tailscale) startDNSServer() error {
+	if !t.serveDNS {
+		log.Debug("DNS server disabled by configuration")
+		return nil
+	}
+	if t.srv == nil {
+		log.Debug("DNS server not started: tsnet server not available")
+		return nil
+	}
+
+	ip4, ip6 := t.srv.TailscaleIPs()
+	if !ip4.IsValid() && !ip6.IsValid() {
+		log.Debug("DNS server not started: no Tailscale IPs available yet")
+		return nil
+	}
+
+	var bindAddr string
+	if ip4.IsValid() {
+		bindAddr = ip4.String()
+	} else {
+		bindAddr = ip6.String()
+	}
+
+	udpConn, err := t.srv.ListenPacket("udp", bindAddr+":53")
+	if err != nil {
+		return fmt.Errorf("failed to create UDP listener on %s:53: %w", bindAddr, err)
+	}
+	t.dnsConn = udpConn
+
+	tcpLn, err := t.srv.Listen("tcp", bindAddr+":53")
+	if err != nil {
+		udpConn.Close()
+		return fmt.Errorf("failed to create TCP listener on %s:53: %w", bindAddr, err)
+	}
+	t.dnsTCP = tcpLn
+
+	t.dnsServer = &dns.Server{
+		PacketConn: udpConn,
+		Listener:   tcpLn,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			t.ServeDNS(context.Background(), w, r)
+		}),
+	}
+
+	go func() {
+		if err := t.dnsServer.ActivateAndServe(); err != nil {
+			log.Errorf("DNS server error: %v", err)
+		}
+	}()
+
+	log.Infof("DNS server started on UDP/TCP port 53 (%s)", bindAddr)
+	return nil
 }


### PR DESCRIPTION
- New 'dns on/off' configuration option to enable DNS server
- Listens on UDP/TCP port 53 on the Tailscale network interface
- Allows other tailnet machines to use this node as DNS resolver
- Updates README with configuration example and usage details

## Rationale

I was searching for a way to make the dns server, running in a docker container, available to all machines in my tailnet. This seemed to be the only (and correct) way to solve that.

I'd understand If you would not be interested in this. I can also maintain this in my fork otherwise.