### PR TITLE
Improve Tailscale services support

### DIFF
--- a/tailscale.go
+++ b/tailscale.go
@@ -3,7 +3,6 @@ package tailscale
 import (
 	"context"
 	"fmt"
-	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -145,21 +144,18 @@ func (t *Tailscale) processNetMap(nm *netmap.NetworkMap) {
 		entries[hostname] = entry
 	}
 
-	// Grab service (VIP) definitions from the only place the API seems to return them accessible
-	// via the netmap.
-	for _, rec := range nm.DNS.ExtraRecords {
-		name := strings.Split(rec.Name, ".")[0]
-		ip, err := netip.ParseAddr(rec.Value)
-		if err != nil {
-			log.Errorf("Error parsing DNS extra record value \"%s\" as netip: %v", rec.Value, err)
-		}
+	// Grab service (VIP) definitions
+	for _, svc := range nm.Services() {
+		name := svc.Name.WithoutPrefix()
 		if _, ok := entries[name]; !ok {
 			entries[name] = map[string][]string{}
 		}
-		if ip.Is6() {
-			entries[name]["AAAA"] = append(entries[name]["AAAA"], ip.String())
-		} else {
-			entries[name]["A"] = append(entries[name]["A"], ip.String())
+		for _, addr := range svc.Addrs {
+			if addr.Is6() {
+				entries[name]["AAAA"] = append(entries[name]["AAAA"], addr.String())
+			} else {
+				entries[name]["A"] = append(entries[name]["A"], addr.String())
+			}
 		}
 	}
 

--- a/tailscale_test.go
+++ b/tailscale_test.go
@@ -12,6 +12,16 @@ import (
 func TestProcessNetMap(t *testing.T) {
 	ts := &Tailscale{zone: "example.com"}
 
+	svc_cap, _ := tailcfg.MarshalCapJSON(
+		&tailcfg.ServiceDetails{
+			Name: "svc:vip-service",
+			Addrs: []netip.Addr{
+				netip.MustParseAddr("100.0.0.5"),
+				netip.MustParseAddr("fd7a:115c:a1e0::5"),
+			},
+		},
+	)
+
 	self := (&tailcfg.Node{
 		ComputedName: "self",
 		Addresses: []netip.Prefix{
@@ -19,6 +29,11 @@ func TestProcessNetMap(t *testing.T) {
 			netip.MustParsePrefix("fd7a:115c:a1e0::1/128"),
 		},
 		Tags: []string{"tag:cname-app"},
+		CapMap: tailcfg.NodeCapMap{
+			"services/vip-service": {
+					svc_cap,
+			},
+		},
 	}).View()
 
 	nm := &netmap.NetworkMap{
@@ -52,18 +67,6 @@ func TestProcessNetMap(t *testing.T) {
 				},
 				Tags: []string{"tag:cname-app"},
 			}).View(),
-		},
-		DNS: tailcfg.DNSConfig{
-			ExtraRecords: []tailcfg.DNSRecord{
-				{
-					Name:  "vip-service.tail-scale.ts.net",
-					Value: "100.0.0.5",
-				},
-				{
-					Name:  "vip-service.tail-scale.ts.net",
-					Value: "fd7a:115c:a1e0::5",
-				},
-			},
 		},
 	}
 
@@ -99,6 +102,10 @@ func TestProcessNetMap(t *testing.T) {
 		},
 		"app": {
 			"CNAME": {"self.example.com."},
+		},
+		"vip-service": {
+			"A":    {"100.0.0.5"},
+			"AAAA": {"fd7a:115c:a1e0::5"},
 		},
 	}
 	if !cmp.Equal(ts.entries, want) {


### PR DESCRIPTION
Because of what was available at the time, the current implementation to support Tailscale services requires MagicDNS to be enabled (`ExtraRecords` is not populated when MagicDNS is disabled).

As Tailscale [now exposes](https://github.com/tailscale/tailscale/commit/4fcce6000d3d3f79d1ac1fca571a50efb059cbf2) services as capabilities available under `SelfNode` (and through a `NetworkMap` helper function), this PR aims to replace the previous implementation and allow the generation of DNS records for services without requiring MagicDNS.